### PR TITLE
Add The Black Formatter as a Github Action

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: Black Formatter 
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@22.12.0
+        with:
+          options: "--check"


### PR DESCRIPTION
I have heard about this formatter before, and seems pretty easy to set-up for IDEA IDEs and vs-code.

You can read more about it here: https://black.readthedocs.io/en/stable/index.html