### PR TITLE
Change metrics to plugin architecture

### DIFF
--- a/byoqm/main.py
+++ b/byoqm/main.py
@@ -7,8 +7,8 @@ import click
 
 def parse_src_root() -> Path:
     if len(sys.argv) == 1:
-            print("Make sure to provide the path to source code")
-            exit(1)
+        print("Make sure to provide the path to source code")
+        exit(1)
     path_to_src = Path(sys.argv[1])
     if not path_to_src.exists():
         print(f"The source code at {path_to_src.resolve()} does not exist")

--- a/byoqm/main.py
+++ b/byoqm/main.py
@@ -6,6 +6,9 @@ import click
 
 
 def parse_src_root() -> Path:
+    if len(sys.argv) == 1:
+            print("Make sure to provide the path to source code")
+            exit(1)
     path_to_src = Path(sys.argv[1])
     if not path_to_src.exists():
         print(f"The source code at {path_to_src.resolve()} does not exist")

--- a/byoqm/main.py
+++ b/byoqm/main.py
@@ -5,18 +5,6 @@ from byoqm.visuals.dashboard import Dashboard
 import click
 
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
-
-    return path_to_src
-
-
 @click.command()
 @click.argument("src_root", required=True)
 @click.argument("quality_model", required=True)

--- a/byoqm/metric/metric.py
+++ b/byoqm/metric/metric.py
@@ -8,4 +8,7 @@ class Metric(ABC):
 
     @abstractmethod
     def run(self) -> int | float:
+        """
+        run returns a number that is the measurement of that specific metric.
+        """
         pass

--- a/byoqm/metric/metric.py
+++ b/byoqm/metric/metric.py
@@ -1,14 +1,10 @@
 from abc import ABC, abstractmethod
-import subprocess
 from pathlib import Path
 
-
-class Metric:
-    def __init__(self, path: Path):
-        self.path = path.resolve()
-        self.name = path.name
-
-    def measure(self) -> int | float:
-        process = subprocess.run([self.path], stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        return result
+class Metric(ABC):
+    def __init__(self):
+        pass
+    
+    @abstractmethod
+    def run(self) -> int | float:
+        pass

--- a/byoqm/metric/metric.py
+++ b/byoqm/metric/metric.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 
+
 class Metric(ABC):
     def __init__(self):
         pass
-    
+
     @abstractmethod
     def run(self) -> int | float:
         pass

--- a/byoqm/runner/runner.py
+++ b/byoqm/runner/runner.py
@@ -83,7 +83,7 @@ class Runner:
             module = importlib.util.module_from_spec(spec)
             sys.modules[metric] = module
             spec.loader.exec_module(module)
-            module.metric.set_coordinator(self._coordinator)
+            module.metric.coordinator = self._coordinator
             results[metric] = int(module.metric.run())
 
         return results

--- a/byoqm/runner/runner.py
+++ b/byoqm/runner/runner.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from typing import Dict
 
 from test.test_support import os
+from byoqm.metric.metric import Metric
 
 from byoqm.qualitymodel.qualitymodel import QualityModel
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 
 class Runner:
@@ -25,6 +27,7 @@ class Runner:
         self._model_name: str = model_name
         self._output_dir = output_path
         self._save_file = save_file
+        self._coordinator = SourceCoordinator(self._src_root, "python")
 
     def _load(self, model_name: str) -> QualityModel:
         """
@@ -75,11 +78,13 @@ class Runner:
         results = {}
 
         metrics = self._model.getDesc()["metrics"]
-        for metric, exec_path in metrics.items():
-            cmd = [f"./{exec_path}", self._src_root]
-            process = subprocess.run(cmd, stdout=subprocess.PIPE)
-            result = process.stdout.decode("utf-8").strip()
-            results[metric] = int(result)
+        for metric,metric_file in metrics.items():
+            spec = importlib.util.spec_from_file_location("metric", metric_file)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[metric] = module
+            spec.loader.exec_module(module)
+            module.metric.set_coordinator(self._coordinator)
+            results[metric] = int(module.metric.run())
 
         return results
 

--- a/byoqm/runner/runner.py
+++ b/byoqm/runner/runner.py
@@ -78,7 +78,7 @@ class Runner:
         results = {}
 
         metrics = self._model.getDesc()["metrics"]
-        for metric,metric_file in metrics.items():
+        for metric, metric_file in metrics.items():
             spec = importlib.util.spec_from_file_location("metric", metric_file)
             module = importlib.util.module_from_spec(spec)
             sys.modules[metric] = module

--- a/byoqm/source_coordinator/source_coordinator.py
+++ b/byoqm/source_coordinator/source_coordinator.py
@@ -3,7 +3,7 @@ from tree_sitter import Language, Parser
 import tree_sitter
 
 
-_TREESITTER_BUILD: Path = Path("build/my-languages.so").resolve()
+_TREESITTER_BUILD: Path = Path("build/my-languages.so")
 
 
 class SourceCoordinator:

--- a/byoqm/source_coordinator/source_coordinator.py
+++ b/byoqm/source_coordinator/source_coordinator.py
@@ -8,7 +8,11 @@ _TREESITTER_BUILD: Path = Path("build/my-languages.so").resolve()
 
 class SourceCoordinator:
     def __init__(self, src_root: Path, langauge: str):
-        self.src_root = src_root
+        if src_root.is_file():
+            self.src_paths = [src_root]
+        else:
+            self.src_paths = [file for file in src_root.glob("**/*.py")]
+
         self.language = Language(_TREESITTER_BUILD.__str__(), langauge)
         self.asts = {}
 
@@ -24,7 +28,7 @@ class SourceCoordinator:
         Throws a ValueError when the file to parse is not a child path of the given
         src_root.
         """
-        if not for_file.is_relative_to(self.src_root):
+        if for_file not in self.src_paths:
             raise ValueError(
                 "The file to parse must be a child path of of the src_root"
             )

--- a/metrics/MethodArguments.sh
+++ b/metrics/MethodArguments.sh
@@ -1,2 +1,0 @@
-#!/bin/bash 
-echo 7

--- a/metrics/argument_count.py
+++ b/metrics/argument_count.py
@@ -1,57 +1,33 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser
-import ast
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
+class ArgumentCount(Metric):
+    def __init__(self):
+        self._coordinator = None
 
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
+    def _parse(self,ast):
+        count = 0
+        query = self._coordinator.language.query(
+            """
+            (function_definition
+                parameters: (parameters) @function.parameters)
+            """
+        )
+        captures = query.captures(ast.root_node)
+        for node, _ in captures:
+            if node.named_child_count > 4:
+                count += 1
 
-    return path_to_src
+        return count
 
-
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
-
-
-def _parse(file):
-    count = 0
-    tree = parser.parse(bytes(file.read(), "utf8"))
-    query = PY_LANGUAGE.query(
-        """
-        (function_definition
-            parameters: (parameters) @function.parameters)
-        """
-    )
-    captures = query.captures(tree.root_node)
-    for node, _ in captures:
-        if node.named_child_count > 4:
-            count += 1
-
-    return count
-
-
-print(parse())
+metric = ArgumentCount()

--- a/metrics/argument_count.py
+++ b/metrics/argument_count.py
@@ -2,11 +2,12 @@
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
+
 class ArgumentCount(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -15,7 +16,7 @@ class ArgumentCount(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-    def _parse(self,ast):
+    def _parse(self, ast):
         count = 0
         query = self._coordinator.language.query(
             """
@@ -29,5 +30,6 @@ class ArgumentCount(Metric):
                 count += 1
 
         return count
+
 
 metric = ArgumentCount()

--- a/metrics/argument_count.py
+++ b/metrics/argument_count.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/argument_count.py
+++ b/metrics/argument_count.py
@@ -5,20 +5,17 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class ArgumentCount(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _parse(self, ast):
         count = 0
-        query = self._coordinator.language.query(
+        query = self.coordinator.language.query(
             """
             (function_definition
                 parameters: (parameters) @function.parameters)

--- a/metrics/complex_logic.py
+++ b/metrics/complex_logic.py
@@ -7,7 +7,7 @@ class ComplexLogic(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -16,11 +16,10 @@ class ComplexLogic(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-
-    def _parse(self,ast):
+    def _parse(self, ast):
         count = 0
         query = self._coordinator.language.query(
-        """
+            """
             (_
                 condition: (boolean_operator) @function.boolean_operator)
             (_
@@ -41,5 +40,6 @@ class ComplexLogic(Metric):
             if boolean_count > 2:
                 count += 1
         return count
+
 
 metric = ComplexLogic()

--- a/metrics/complex_logic.py
+++ b/metrics/complex_logic.py
@@ -5,20 +5,17 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class ComplexLogic(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _parse(self, ast):
         count = 0
-        query = self._coordinator.language.query(
+        query = self.coordinator.language.query(
             """
             (_
                 condition: (boolean_operator) @function.boolean_operator)

--- a/metrics/complex_logic.py
+++ b/metrics/complex_logic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/complex_logic.py
+++ b/metrics/complex_logic.py
@@ -1,45 +1,25 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser, Node
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+class ComplexLogic(Metric):
+    def __init__(self):
+        self._coordinator = None
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-    return path_to_src
-
-
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
 
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
-
-
-def _parse(file):
-    tree = parser.parse(bytes(file.read(), "utf8"))
-    query = PY_LANGUAGE.query(
+    def _parse(self,ast):
+        count = 0
+        query = self._coordinator.language.query(
         """
             (_
                 condition: (boolean_operator) @function.boolean_operator)
@@ -47,20 +27,19 @@ def _parse(file):
                 right: (boolean_operator) @function.boolean_operator)
 
             """
-    )
-    captures = query.captures(tree.root_node)
-    count = 0
-    for capture in captures:
-        # initial count is always at least 2 (right and left)
-        boolean_count = 2
-        node = capture[0]
-        while node.child_by_field_name("left").type == "boolean_operator":
-            boolean_count += 1
-            node = node.child_by_field_name("left")
-            # change the value below to a parameter when parameterizing
-        if boolean_count > 2:
-            count += 1
-    return count
+        )
+        captures = query.captures(ast.root_node)
+        count = 0
+        for capture in captures:
+            # initial count is always at least 2 (right and left)
+            boolean_count = 2
+            node = capture[0]
+            while node.child_by_field_name("left").type == "boolean_operator":
+                boolean_count += 1
+                node = node.child_by_field_name("left")
+                # change the value below to a parameter when parameterizing
+            if boolean_count > 2:
+                count += 1
+        return count
 
-
-print(parse())
+metric = ComplexLogic()

--- a/metrics/file_length.py
+++ b/metrics/file_length.py
@@ -5,14 +5,11 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class FileLength(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
+        for file in self.coordinator.src_paths:
             with open(file) as f:
                 count += self._parse(f)
         return count

--- a/metrics/file_length.py
+++ b/metrics/file_length.py
@@ -1,48 +1,28 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+class FileLength(Metric):
+    def __init__(self):
+        self._coordinator = None
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-    return path_to_src
-
-
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
-
-
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
             with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
+                count += self._parse(f)
+        return count
 
 
-def _parse(file):
-    count = 0
-    loc = sum(1 for line in file if line.rstrip())
-    if loc > 250:
-        count += 1
-    return count
+    def _parse(self, file):
+        count = 0
+        loc = sum(1 for line in file if line.rstrip())
+        if loc > 250:
+            count += 1
+        return count
 
-
-print(parse())
+metric = FileLength()

--- a/metrics/file_length.py
+++ b/metrics/file_length.py
@@ -7,7 +7,7 @@ class FileLength(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -17,12 +17,12 @@ class FileLength(Metric):
                 count += self._parse(f)
         return count
 
-
     def _parse(self, file):
         count = 0
         loc = sum(1 for line in file if line.rstrip())
         if loc > 250:
             count += 1
         return count
+
 
 metric = FileLength()

--- a/metrics/file_length.py
+++ b/metrics/file_length.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -1,52 +1,38 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 from defusedxml.ElementTree import parse
 from io import StringIO
 import subprocess
 
-
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
-
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
-
-    return path_to_src
-
-
 TOKENS = 35
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
-src_root = parse_src_root()
+
+class IdenticalBlocksofCode(Metric):
+    def __init__(self):
+        self._coordinator = None
+
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
+
+    def run(self):
+        count = self.identical_blocks_of_code([str(file) for file in self._coordinator.src_paths])
+        return count
 
 
-def identical_blocks_of_code() -> int | float:
-    files = []
-    if src_root.is_file():
-        files = [str(src_root)]
-    else:
-        files = [str(file) for file in src_root.glob("**/*.py")]
-    filestring = f"{files}"
-    filestring = filestring[1 : len(filestring) - 1]
-    count = 0
-    res = subprocess.run(
-        f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --dir {filestring} --format xml",
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
-    et = parse(StringIO(res.stdout))
-    for child in et.getroot():
-        if child.tag == "duplication":
-            count += 1
-    return count
+    def identical_blocks_of_code(self,files) -> int | float:
+        filestring = f"{files}"
+        filestring = filestring[1 : len(filestring) - 1]
+        count = 0
+        res = subprocess.run(
+            f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --dir {filestring} --format xml",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        et = parse(StringIO(res.stdout))
+        for child in et.getroot():
+            if child.tag == "duplication":
+                count += 1
+        return count
 
-
-print(identical_blocks_of_code())
+metric = IdenticalBlocksofCode()

--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 from defusedxml.ElementTree import parse

--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -7,19 +7,21 @@ import subprocess
 
 TOKENS = 35
 
+
 class IdenticalBlocksofCode(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
-        count = self.identical_blocks_of_code([str(file) for file in self._coordinator.src_paths])
+        count = self.identical_blocks_of_code(
+            [str(file) for file in self._coordinator.src_paths]
+        )
         return count
 
-
-    def identical_blocks_of_code(self,files) -> int | float:
+    def identical_blocks_of_code(self, files) -> int | float:
         filestring = f"{files}"
         filestring = filestring[1 : len(filestring) - 1]
         count = 0
@@ -34,5 +36,6 @@ class IdenticalBlocksofCode(Metric):
             if child.tag == "duplication":
                 count += 1
         return count
+
 
 metric = IdenticalBlocksofCode()

--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -10,14 +10,11 @@ TOKENS = 35
 
 class IdenticalBlocksofCode(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = self.identical_blocks_of_code(
-            [str(file) for file in self._coordinator.src_paths]
+            [str(file) for file in self.coordinator.src_paths]
         )
         return count
 

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -2,11 +2,12 @@
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
+
 class MethodCount(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -15,8 +16,7 @@ class MethodCount(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-
-    def _parse(self,ast):
+    def _parse(self, ast):
         count = 0
         query = self._coordinator.language.query(
             """
@@ -27,5 +27,6 @@ class MethodCount(Metric):
         if len(captures) > 20:
             count += 1
         return count
-    
+
+
 metric = MethodCount()

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -7,10 +7,6 @@ from byoqm.metric.metric import Metric
 
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
-PY_LANGUAGE = Language("build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
-
 class MethodCount(Metric):
     def __init__(self):
         self._coordinator = None
@@ -27,7 +23,7 @@ class MethodCount(Metric):
 
     def _parse(self,ast):
         count = 0
-        query = PY_LANGUAGE.query(
+        query = self._coordinator.language.query(
             """
             (_ (function_definition) @function)
             """

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -3,52 +3,38 @@ import ast
 from pathlib import Path
 from tree_sitter import Language, Parser
 import sys
+from byoqm.metric.metric import Metric
 
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+
+PY_LANGUAGE = Language("build/my-languages.so", "python")
 parser = Parser()
 parser.set_language(PY_LANGUAGE)
 
+class MethodCount(Metric):
+    def __init__(self):
+        self._coordinator = None
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
-
-    return path_to_src
-
-
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
 
-def _parse(file):
-    count = 0
-    tree = parser.parse(bytes(file.read(), "utf8"))
-    query = PY_LANGUAGE.query(
-        """
-        (_ (function_definition) @function)
-        """
-    )
-    captures = query.captures(tree.root_node)
-    if len(captures) > 20:
-        count += 1
-    return count
-
-
-print(parse())
+    def _parse(self,ast):
+        count = 0
+        query = PY_LANGUAGE.query(
+            """
+            (_ (function_definition) @function)
+            """
+        )
+        captures = query.captures(ast.root_node)
+        if len(captures) > 20:
+            count += 1
+        return count
+    
+metric = MethodCount()

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
-import ast
-from pathlib import Path
-from tree_sitter import Language, Parser
-import sys
 from byoqm.metric.metric import Metric
-
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class MethodCount(Metric):

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -5,20 +5,17 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class MethodCount(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _parse(self, ast):
         count = 0
-        query = self._coordinator.language.query(
+        query = self.coordinator.language.query(
             """
             (_ (function_definition) @function)
             """

--- a/metrics/method_length.py
+++ b/metrics/method_length.py
@@ -1,59 +1,37 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser, Node
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
+class MethodLength(Metric):
+    def __init__(self):
+        self._coordinator = None
 
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
-
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
-
-    return path_to_src
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
 
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
-
-
-def _parse(file):
-    count = 0
-    tree = parser.parse(bytes(file.read(), "utf8"))
-    query = PY_LANGUAGE.query(
+    def _parse(self,ast):
+        count = 0
+        query = self._coordinator.language.query(
         """
                 (function_definition
                     body: (block) @function.block)
                 """
-    )
-    captures = query.captures(tree.root_node)
-    for node in captures:
-        n = node[0]
-        length = (
-            n.end_point[0] - n.start_point[0] + 1
-        )  # length is zero indexed - therefore we add 1 at the end
-        if length > 25:
-            count += 1
-    return count
+        )
+        captures = query.captures(ast.root_node)
+        for node in captures:
+            n = node[0]
+            length = (
+                n.end_point[0] - n.start_point[0] + 1
+            )  # length is zero indexed - therefore we add 1 at the end
+            if length > 25:
+                count += 1
+        return count
 
-
-print(parse())
+metric = MethodLength()

--- a/metrics/method_length.py
+++ b/metrics/method_length.py
@@ -2,11 +2,12 @@
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
+
 class MethodLength(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -15,11 +16,10 @@ class MethodLength(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-
-    def _parse(self,ast):
+    def _parse(self, ast):
         count = 0
         query = self._coordinator.language.query(
-        """
+            """
                 (function_definition
                     body: (block) @function.block)
                 """
@@ -33,5 +33,6 @@ class MethodLength(Metric):
             if length > 25:
                 count += 1
         return count
+
 
 metric = MethodLength()

--- a/metrics/method_length.py
+++ b/metrics/method_length.py
@@ -5,20 +5,17 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class MethodLength(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _parse(self, ast):
         count = 0
-        query = self._coordinator.language.query(
+        query = self.coordinator.language.query(
             """
                 (function_definition
                     body: (block) @function.block)

--- a/metrics/method_length.py
+++ b/metrics/method_length.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/nested_controlflows.py
+++ b/metrics/nested_controlflows.py
@@ -5,15 +5,12 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class NestedControlflows(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _unique(self, not_unique_list):
@@ -26,7 +23,7 @@ class NestedControlflows(Metric):
 
     def _parse(self, ast) -> int:
         count = 0
-        query = self._coordinator.language.query(
+        query = self.coordinator.language.query(
             """
                 (module [
                 (if_statement 
@@ -55,7 +52,7 @@ class NestedControlflows(Metric):
                     """
         )
         inital_nodes = self._unique(query.captures(ast.root_node))
-        sub_node_query = self._coordinator.language.query(
+        sub_node_query = self.coordinator.language.query(
             """
                 (_ [
                 (if_statement 

--- a/metrics/nested_controlflows.py
+++ b/metrics/nested_controlflows.py
@@ -7,7 +7,7 @@ class NestedControlflows(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -16,7 +16,7 @@ class NestedControlflows(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-    def _unique(self,not_unique_list):
+    def _unique(self, not_unique_list):
         unique_list = []
 
         for x in not_unique_list:
@@ -24,8 +24,7 @@ class NestedControlflows(Metric):
                 unique_list.append(x)
         return unique_list
 
-
-    def _parse(self,ast) -> int:
+    def _parse(self, ast) -> int:
         count = 0
         query = self._coordinator.language.query(
             """
@@ -86,5 +85,6 @@ class NestedControlflows(Metric):
                         found = True
 
         return count
+
 
 metric = NestedControlflows()

--- a/metrics/nested_controlflows.py
+++ b/metrics/nested_controlflows.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/nested_controlflows.py
+++ b/metrics/nested_controlflows.py
@@ -1,113 +1,90 @@
 #!/usr/bin/env python
-from pathlib import Path
-from tree_sitter import Language, Parser
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+class NestedControlflows(Metric):
+    def __init__(self):
+        self._coordinator = None
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-    return path_to_src
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
+    def _unique(self,not_unique_list):
+        unique_list = []
 
-def unique(not_unique_list):
-    unique_list = []
-
-    for x in not_unique_list:
-        if x not in unique_list:
-            unique_list.append(x)
-    return unique_list
-
-
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
-src = parse_src_root()
-py_files = src.glob("**/*.py")
+        for x in not_unique_list:
+            if x not in unique_list:
+                unique_list.append(x)
+        return unique_list
 
 
-def parse():
-    count = 0
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-    return count
-
-
-def _parse(file) -> int:
-    count = 0
-    tree = parser.parse(bytes(file.read(), "utf-8"))
-    query = PY_LANGUAGE.query(
-        """
-            (module [
-            (if_statement 
-                consequence: (block) @cons
-                    )
-            (if_statement 
-                consequence: (block) @cons
-                alternative: (_ [body: (block) consequence: (block) ] @cons) 
-                    )
-            (while_statement body: (block) @cons)
-            (for_statement body: (block) @cons)]
-            )
-            
-            (function_definition
-            body: (block [
+    def _parse(self,ast) -> int:
+        count = 0
+        query = self._coordinator.language.query(
+            """
+                (module [
                 (if_statement 
                     consequence: (block) @cons
                         )
                 (if_statement 
                     consequence: (block) @cons
-                    alternative: (_ [body: (block) consequence: (block)] @cons)
+                    alternative: (_ [body: (block) consequence: (block) ] @cons) 
                         )
                 (while_statement body: (block) @cons)
-                (for_statement body: (block) @cons)])
-            )
-                """
-    )
-    inital_nodes = unique(query.captures(tree.root_node))
-    sub_node_query = PY_LANGUAGE.query(
-        """
-            (_ [
-            (if_statement 
-                consequence: (block) @cons
-                    )
-            (if_statement 
-                consequence: (block) @cons
-                alternative: (_ [body: (block) consequence: (block) ] @cons) 
-                    )
-            (while_statement body: (block) @cons)
-            (for_statement body: (block) @cons)]
-            )
-                """
-    )
-    for node, _ in inital_nodes:
-        found = False
-        nodes2 = sub_node_query.captures(node)
-        for node2, _ in nodes2:
-            if found:
-                break
-            nodes3 = sub_node_query.captures(node2)
-            for node3, _ in nodes3:
+                (for_statement body: (block) @cons)]
+                )
+                
+                (function_definition
+                body: (block [
+                    (if_statement 
+                        consequence: (block) @cons
+                            )
+                    (if_statement 
+                        consequence: (block) @cons
+                        alternative: (_ [body: (block) consequence: (block)] @cons)
+                            )
+                    (while_statement body: (block) @cons)
+                    (for_statement body: (block) @cons)])
+                )
+                    """
+        )
+        inital_nodes = self._unique(query.captures(ast.root_node))
+        sub_node_query = self._coordinator.language.query(
+            """
+                (_ [
+                (if_statement 
+                    consequence: (block) @cons
+                        )
+                (if_statement 
+                    consequence: (block) @cons
+                    alternative: (_ [body: (block) consequence: (block) ] @cons) 
+                        )
+                (while_statement body: (block) @cons)
+                (for_statement body: (block) @cons)]
+                )
+                    """
+        )
+        for node, _ in inital_nodes:
+            found = False
+            nodes2 = sub_node_query.captures(node)
+            for node2, _ in nodes2:
                 if found:
                     break
-                if len(sub_node_query.captures(node3)) > 0:
-                    count += 1
-                    found = True
+                nodes3 = sub_node_query.captures(node2)
+                for node3, _ in nodes3:
+                    if found:
+                        break
+                    if len(sub_node_query.captures(node3)) > 0:
+                        count += 1
+                        found = True
 
-    return count
+        return count
 
-
-print(parse())
+metric = NestedControlflows()

--- a/metrics/return_statements.py
+++ b/metrics/return_statements.py
@@ -7,7 +7,7 @@ class ReturnStatements(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
@@ -16,11 +16,10 @@ class ReturnStatements(Metric):
             count += self._parse(self._coordinator.getAst(file))
         return count
 
-
-    def _parse(self,ast):
+    def _parse(self, ast):
         count = 0
         query_functions = self._coordinator.language.query(
-        """
+            """
         (_ (function_definition) @function)
         """
         )
@@ -36,5 +35,6 @@ class ReturnStatements(Metric):
             if len(captures) > 4:
                 count += 1
         return count
+
 
 metric = ReturnStatements()

--- a/metrics/return_statements.py
+++ b/metrics/return_statements.py
@@ -1,62 +1,40 @@
 #!/usr/bin/env python
-from pathlib import Path
-import ast
-from tree_sitter import Language, Parser, Node
-import sys
-
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
+class ReturnStatements(Metric):
+    def __init__(self):
+        self._coordinator = None
 
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
 
-    return path_to_src
-
-
-def parse():
-    count = 0
-    src = parse_src_root()
-    if src.is_file():
-        with src.open() as f:
-            count = _parse(f)
-    else:
-        py_files = src.glob("**/*.py")
-        for file in py_files:
-            with open(file) as f:
-                count += _parse(f)
-        py_files.close()
-    return count
+    def run(self):
+        count = 0
+        for file in self._coordinator.src_paths:
+            count += self._parse(self._coordinator.getAst(file))
+        return count
 
 
-def _parse(file):
-    count = 0
-    tree = parser.parse(bytes(file.read(), "utf8"))
-    query_functions = PY_LANGUAGE.query(
+    def _parse(self,ast):
+        count = 0
+        query_functions = self._coordinator.language.query(
         """
         (_ (function_definition) @function)
         """
-    )
-    query_return = PY_LANGUAGE.query(
-        """
-        (_ (return_statement) @return)
-        """
-    )
+        )
+        query_return = self._coordinator.language.query(
+            """
+            (_ (return_statement) @return)
+            """
+        )
 
-    functions = query_functions.captures(tree.root_node)
-    for function_node, _ in functions:
-        captures = query_return.captures(function_node)
-        if len(captures) > 4:
-            count += 1
-    return count
+        functions = query_functions.captures(ast.root_node)
+        for function_node, _ in functions:
+            captures = query_return.captures(function_node)
+            if len(captures) > 4:
+                count += 1
+        return count
 
-
-print(parse())
+metric = ReturnStatements()

--- a/metrics/return_statements.py
+++ b/metrics/return_statements.py
@@ -5,25 +5,22 @@ from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 
 class ReturnStatements(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = 0
-        for file in self._coordinator.src_paths:
-            count += self._parse(self._coordinator.getAst(file))
+        for file in self.coordinator.src_paths:
+            count += self._parse(self.coordinator.getAst(file))
         return count
 
     def _parse(self, ast):
         count = 0
-        query_functions = self._coordinator.language.query(
+        query_functions = self.coordinator.language.query(
             """
         (_ (function_definition) @function)
         """
         )
-        query_return = self._coordinator.language.query(
+        query_return = self.coordinator.language.query(
             """
             (_ (return_statement) @return)
             """

--- a/metrics/return_statements.py
+++ b/metrics/return_statements.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from byoqm.metric.metric import Metric
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -1,52 +1,38 @@
 #!/usr/bin/env python
 from io import StringIO
-from pathlib import Path
 import subprocess
-from tree_sitter import Language, Parser
-import sys
+from byoqm.metric.metric import Metric
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
 from defusedxml.ElementTree import parse
 
-
-def parse_src_root() -> Path:
-    if len(sys.argv) == 1:
-        print("Make sure to provide the path to source code")
-        exit(1)
-
-    path_to_src = Path(sys.argv[1])
-    if not path_to_src.exists():
-        print(f"The source code at {path_to_src.resolve()} does not exist")
-        exit(1)
-
-    return path_to_src
-
-
 TOKENS = 35
-PY_LANGUAGE = Language("./build/my-languages.so", "python")
-parser = Parser()
-parser.set_language(PY_LANGUAGE)
-src_root = parse_src_root()
+
+class SimilarBlocksofCode(Metric):
+    def __init__(self):
+        self._coordinator = None
+
+    def set_coordinator(self, coordinator : SourceCoordinator):
+        self._coordinator = coordinator
+
+    def run(self):
+        count = self.similar_blocks_of_code([str(file) for file in self._coordinator.src_paths])
+        return count
 
 
-def similar_blocks_of_code() -> int | float:
-    files = []
-    if src_root.is_file():
-        files = [str(src_root)]
-    else:
-        files = [str(file) for file in src_root.glob("**/*.py")]
-    filestring = f"{files}"
-    filestring = filestring[1 : len(filestring) - 1]
-    count = 0
-    res = subprocess.run(
-        f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --ignore-identifiers --ignore-literals --dir {filestring} --format xml",
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
-    et = parse(StringIO(res.stdout))
-    for child in et.getroot():
-        if child.tag == "duplication":
-            count += 1
-    return count
-
-
-print(similar_blocks_of_code())
+    def similar_blocks_of_code(self,files) -> int | float:
+        filestring = f"{files}"
+        filestring = filestring[1 : len(filestring) - 1]
+        count = 0
+        res = subprocess.run(
+            f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --ignore-identifiers --ignore-literals --dir {filestring} --format xml",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        et = parse(StringIO(res.stdout))
+        for child in et.getroot():
+            if child.tag == "duplication":
+                count += 1
+        return count
+    
+metric = SimilarBlocksofCode()

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -7,19 +7,21 @@ from defusedxml.ElementTree import parse
 
 TOKENS = 35
 
+
 class SimilarBlocksofCode(Metric):
     def __init__(self):
         self._coordinator = None
 
-    def set_coordinator(self, coordinator : SourceCoordinator):
+    def set_coordinator(self, coordinator: SourceCoordinator):
         self._coordinator = coordinator
 
     def run(self):
-        count = self.similar_blocks_of_code([str(file) for file in self._coordinator.src_paths])
+        count = self.similar_blocks_of_code(
+            [str(file) for file in self._coordinator.src_paths]
+        )
         return count
 
-
-    def similar_blocks_of_code(self,files) -> int | float:
+    def similar_blocks_of_code(self, files) -> int | float:
         filestring = f"{files}"
         filestring = filestring[1 : len(filestring) - 1]
         count = 0
@@ -34,5 +36,6 @@ class SimilarBlocksofCode(Metric):
             if child.tag == "duplication":
                 count += 1
         return count
-    
+
+
 metric = SimilarBlocksofCode()

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -10,14 +10,11 @@ TOKENS = 35
 
 class SimilarBlocksofCode(Metric):
     def __init__(self):
-        self._coordinator = None
-
-    def set_coordinator(self, coordinator: SourceCoordinator):
-        self._coordinator = coordinator
+        self.coordinator: SourceCoordinator = None
 
     def run(self):
         count = self.similar_blocks_of_code(
-            [str(file) for file in self._coordinator.src_paths]
+            [str(file) for file in self.coordinator.src_paths]
         )
         return count
 

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from io import StringIO
 import subprocess
 from byoqm.metric.metric import Metric

--- a/metrics/test/test_argument_count.py
+++ b/metrics/test/test_argument_count.py
@@ -7,6 +7,8 @@ from metrics.argument_count import ArgumentCount
 
 class TestArgumentCount(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_argument_count"), "python"

--- a/metrics/test/test_argument_count.py
+++ b/metrics/test/test_argument_count.py
@@ -8,7 +8,9 @@ from metrics.argument_count import ArgumentCount
 class TestArgumentCount(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_argument_count"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_argument_count"), "python"
+        )
         self._argumentcount = ArgumentCount()
         self._argumentcount.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_argument_count.py
+++ b/metrics/test/test_argument_count.py
@@ -12,7 +12,7 @@ class TestArgumentCount(unittest.TestCase):
             Path("./metrics/test/data/test_data_argument_count"), "python"
         )
         self._argumentcount = ArgumentCount()
-        self._argumentcount.set_coordinator(self._coordinator)
+        self._argumentcount.coordinator = self._coordinator
 
     def test_argument_count_given_directory_returns_2(self):
         result = self._argumentcount.run()

--- a/metrics/test/test_argument_count.py
+++ b/metrics/test/test_argument_count.py
@@ -1,21 +1,20 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.argument_count import ArgumentCount
 
 
 class TestArgumentCount(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_argument_count"),"python")
+        self._argumentcount = ArgumentCount()
+        self._argumentcount.set_coordinator(self._coordinator)
 
-    def test_argument_count_given_directory_returns_1(self):
-        cmd = [
-            "./metrics/argument_count.py",
-            "./metrics/test/data/test_data_argument_count",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "2")
+    def test_argument_count_given_directory_returns_2(self):
+        result = self._argumentcount.run()
+        self.assertEqual(result, 2)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_complex_logic.py
+++ b/metrics/test/test_complex_logic.py
@@ -8,7 +8,9 @@ from metrics.complex_logic import ComplexLogic
 class TestComplexLogic(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_complex_logic"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_complex_logic"), "python"
+        )
         self._complexlogic = ComplexLogic()
         self._complexlogic.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_complex_logic.py
+++ b/metrics/test/test_complex_logic.py
@@ -7,6 +7,8 @@ from metrics.complex_logic import ComplexLogic
 
 class TestComplexLogic(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_complex_logic"), "python"

--- a/metrics/test/test_complex_logic.py
+++ b/metrics/test/test_complex_logic.py
@@ -12,7 +12,7 @@ class TestComplexLogic(unittest.TestCase):
             Path("./metrics/test/data/test_data_complex_logic"), "python"
         )
         self._complexlogic = ComplexLogic()
-        self._complexlogic.set_coordinator(self._coordinator)
+        self._complexlogic.coordinator = self._coordinator
 
     def test_complex_logic_given_file_returns_4(self):
         result = self._complexlogic.run()

--- a/metrics/test/test_complex_logic.py
+++ b/metrics/test/test_complex_logic.py
@@ -1,21 +1,20 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.complex_logic import ComplexLogic
 
 
 class TestComplexLogic(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_complex_logic"),"python")
+        self._complexlogic = ComplexLogic()
+        self._complexlogic.set_coordinator(self._coordinator)
 
     def test_complex_logic_given_file_returns_4(self):
-        cmd = [
-            "./metrics/complex_logic.py",
-            "./metrics/test/data/test_data_complex_logic",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "4")
+        result = self._complexlogic.run()
+        self.assertEqual(result, 4)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_file_length.py
+++ b/metrics/test/test_file_length.py
@@ -12,7 +12,7 @@ class TestFileLength(unittest.TestCase):
             Path("./metrics/test/data/test_data_file_length"), "python"
         )
         self._filelength = FileLength()
-        self._filelength.set_coordinator(self._coordinator)
+        self._filelength.coordinator = self._coordinator
 
     def test_file_length_given_file_returns_1(self):
         result = self._filelength.run()

--- a/metrics/test/test_file_length.py
+++ b/metrics/test/test_file_length.py
@@ -8,7 +8,9 @@ from metrics.file_length import FileLength
 class TestFileLength(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_file_length"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_file_length"), "python"
+        )
         self._filelength = FileLength()
         self._filelength.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_file_length.py
+++ b/metrics/test/test_file_length.py
@@ -1,18 +1,20 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.file_length import FileLength
 
 
 class TestFileLength(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_file_length"),"python")
+        self._filelength = FileLength()
+        self._filelength.set_coordinator(self._coordinator)
 
     def test_file_length_given_file_returns_1(self):
-        cmd = ["./metrics/file_length.py", "./metrics/test/data/test_data_file_length"]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "1")
+        result = self._filelength.run()
+        self.assertEqual(result, 1)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_file_length.py
+++ b/metrics/test/test_file_length.py
@@ -7,6 +7,8 @@ from metrics.file_length import FileLength
 
 class TestFileLength(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_file_length"), "python"

--- a/metrics/test/test_identical_codeblocks.py
+++ b/metrics/test/test_identical_codeblocks.py
@@ -8,11 +8,12 @@ from metrics.identical_codeblocks import IdenticalBlocksofCode
 class TestIdenticalCodeBlocks(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_identical_codeblocks"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_identical_codeblocks"), "python"
+        )
         self._identicalcode = IdenticalBlocksofCode()
         self._identicalcode.set_coordinator(self._coordinator)
 
-    
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),
         "CPD doesn't exist in the environment",

--- a/metrics/test/test_identical_codeblocks.py
+++ b/metrics/test/test_identical_codeblocks.py
@@ -1,38 +1,25 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.identical_codeblocks import IdenticalBlocksofCode
 
 
 class TestIdenticalCodeBlocks(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_identical_codeblocks"),"python")
+        self._identicalcode = IdenticalBlocksofCode()
+        self._identicalcode.set_coordinator(self._coordinator)
 
+    
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),
         "CPD doesn't exist in the environment",
     )
     def test_identical_codeblocks_given_file_returns_1(self):
-        cmd = [
-            "./metrics/identical_codeblocks.py",
-            "./metrics/test/data/test_data_identical_codeblocks",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "1")
-
-    @unittest.skipIf(
-        not os.path.exists("../../metrics/cpd"),
-        "CPD doesn't exist in the environment",
-    )
-    def test_identical_codeblocks_given_file_returns_2(self):
-        cmd = [
-            "./metrics/identical_codeblocks.py",
-            "./metrics/test/data/test_data_identical_codeblocks",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "1")
+        result = self._identicalcode.run()
+        self.assertEqual(result, 1)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_identical_codeblocks.py
+++ b/metrics/test/test_identical_codeblocks.py
@@ -7,6 +7,8 @@ from metrics.identical_codeblocks import IdenticalBlocksofCode
 
 class TestIdenticalCodeBlocks(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_identical_codeblocks"), "python"

--- a/metrics/test/test_identical_codeblocks.py
+++ b/metrics/test/test_identical_codeblocks.py
@@ -12,7 +12,7 @@ class TestIdenticalCodeBlocks(unittest.TestCase):
             Path("./metrics/test/data/test_data_identical_codeblocks"), "python"
         )
         self._identicalcode = IdenticalBlocksofCode()
-        self._identicalcode.set_coordinator(self._coordinator)
+        self._identicalcode.coordinator = self._coordinator
 
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -1,21 +1,21 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+
+from metrics.method_count import MethodCount
 
 
 class TestMethodCount(unittest.TestCase):
     def setUp(self):
-        os.chdir("../../")
+        os.chdir("../..")
+        self._coordinator = SourceCoordinator("./metrics/test/data/test_data_method_count","python")
+        self._methodcount = MethodCount()
+        self._methodcount.set_coordinator(self._coordinator)
 
     def test_method_count_given_file_returns_1(self):
-        cmd = [
-            "./metrics/argument_count.py",
-            "./metrics/test/data/test_data_argument_count",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "2")
+        result = self._methodcount.run()
+        self.assertEqual(result, "1")
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -8,14 +8,15 @@ from metrics.method_count import MethodCount
 
 class TestMethodCount(unittest.TestCase):
     def setUp(self):
-        os.chdir("../..")
-        self._coordinator = SourceCoordinator("./metrics/test/data/test_data_method_count","python")
+        os.chdir("../../")
+        print(os.getcwd())
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_method_count"),"python")
         self._methodcount = MethodCount()
         self._methodcount.set_coordinator(self._coordinator)
 
     def test_method_count_given_file_returns_1(self):
         result = self._methodcount.run()
-        self.assertEqual(result, "1")
+        self.assertEqual(result, 1)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -8,7 +8,9 @@ from metrics.method_count import MethodCount
 class TestMethodCount(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_method_count"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_method_count"), "python"
+        )
         self._methodcount = MethodCount()
         self._methodcount.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -7,6 +7,8 @@ from metrics.method_count import MethodCount
 
 class TestMethodCount(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_method_count"), "python"

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -2,14 +2,12 @@ from pathlib import Path
 import unittest
 import os
 from byoqm.source_coordinator.source_coordinator import SourceCoordinator
-
 from metrics.method_count import MethodCount
 
 
 class TestMethodCount(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        print(os.getcwd())
         self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_method_count"),"python")
         self._methodcount = MethodCount()
         self._methodcount.set_coordinator(self._coordinator)

--- a/metrics/test/test_method_count.py
+++ b/metrics/test/test_method_count.py
@@ -12,7 +12,7 @@ class TestMethodCount(unittest.TestCase):
             Path("./metrics/test/data/test_data_method_count"), "python"
         )
         self._methodcount = MethodCount()
-        self._methodcount.set_coordinator(self._coordinator)
+        self._methodcount.coordinator = self._coordinator
 
     def test_method_count_given_file_returns_1(self):
         result = self._methodcount.run()

--- a/metrics/test/test_method_length.py
+++ b/metrics/test/test_method_length.py
@@ -8,7 +8,9 @@ from metrics.method_length import MethodLength
 class TestMethodLength(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_method_length"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_method_length"), "python"
+        )
         self._methodlength = MethodLength()
         self._methodlength.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_method_length.py
+++ b/metrics/test/test_method_length.py
@@ -12,7 +12,7 @@ class TestMethodLength(unittest.TestCase):
             Path("./metrics/test/data/test_data_method_length"), "python"
         )
         self._methodlength = MethodLength()
-        self._methodlength.set_coordinator(self._coordinator)
+        self._methodlength.coordinator = self._coordinator
 
     def test_method_length_given_file_returns_2(self):
         result = self._methodlength.run()

--- a/metrics/test/test_method_length.py
+++ b/metrics/test/test_method_length.py
@@ -7,6 +7,8 @@ from metrics.method_length import MethodLength
 
 class TestMethodLength(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_method_length"), "python"

--- a/metrics/test/test_method_length.py
+++ b/metrics/test/test_method_length.py
@@ -1,21 +1,20 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.method_length import MethodLength
 
 
 class TestMethodLength(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_method_length"),"python")
+        self._methodlength = MethodLength()
+        self._methodlength.set_coordinator(self._coordinator)
 
     def test_method_length_given_file_returns_2(self):
-        cmd = [
-            "./metrics/method_length.py",
-            "./metrics/test/data/test_data_method_length",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "2")
+        result = self._methodlength.run()
+        self.assertEqual(result, 2)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_nested_controlflows.py
+++ b/metrics/test/test_nested_controlflows.py
@@ -12,7 +12,7 @@ class TestNestedControlFlows(unittest.TestCase):
             Path("./metrics/test/data/test_data_nested_controlflows"), "python"
         )
         self._nestedflow = NestedControlflows()
-        self._nestedflow.set_coordinator(self._coordinator)
+        self._nestedflow.coordinator = self._coordinator
 
     @unittest.expectedFailure
     def test_nested_controlflow_given_test_directory_returns_9(self):

--- a/metrics/test/test_nested_controlflows.py
+++ b/metrics/test/test_nested_controlflows.py
@@ -7,6 +7,8 @@ from metrics.nested_controlflows import NestedControlflows
 
 class TestNestedControlFlows(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_nested_controlflows"), "python"

--- a/metrics/test/test_nested_controlflows.py
+++ b/metrics/test/test_nested_controlflows.py
@@ -1,22 +1,21 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.nested_controlflows import NestedControlflows
 
 
 class TestNestedControlFlows(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_nested_controlflows"),"python")
+        self._nestedflow = NestedControlflows()
+        self._nestedflow.set_coordinator(self._coordinator)
 
     @unittest.expectedFailure
     def test_nested_controlflow_given_test_directory_returns_9(self):
-        cmd = [
-            "./metrics/nested_controlflows.py",
-            "./metrics/test/data/test_data_nested_controlflows",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "9")
+        result = self._nestedflow.run()
+        self.assertEqual(result, 9)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_nested_controlflows.py
+++ b/metrics/test/test_nested_controlflows.py
@@ -8,7 +8,9 @@ from metrics.nested_controlflows import NestedControlflows
 class TestNestedControlFlows(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_nested_controlflows"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_nested_controlflows"), "python"
+        )
         self._nestedflow = NestedControlflows()
         self._nestedflow.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_return_statements.py
+++ b/metrics/test/test_return_statements.py
@@ -1,21 +1,20 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.return_statements import ReturnStatements
 
 
 class TestReturnStatements(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_return_statements"),"python")
+        self._returnstmnt = ReturnStatements()
+        self._returnstmnt.set_coordinator(self._coordinator)
 
     def test_return_statements_given_file_returns_2(self):
-        cmd = [
-            "./metrics/return_statements.py",
-            "./metrics/test/data/test_data_return_statements",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "2")
+        result = self._returnstmnt.run()
+        self.assertEqual(result, 2)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_return_statements.py
+++ b/metrics/test/test_return_statements.py
@@ -12,7 +12,7 @@ class TestReturnStatements(unittest.TestCase):
             Path("./metrics/test/data/test_data_return_statements"), "python"
         )
         self._returnstmnt = ReturnStatements()
-        self._returnstmnt.set_coordinator(self._coordinator)
+        self._returnstmnt.coordinator = self._coordinator
 
     def test_return_statements_given_file_returns_2(self):
         result = self._returnstmnt.run()

--- a/metrics/test/test_return_statements.py
+++ b/metrics/test/test_return_statements.py
@@ -7,6 +7,8 @@ from metrics.return_statements import ReturnStatements
 
 class TestReturnStatements(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_return_statements"), "python"

--- a/metrics/test/test_return_statements.py
+++ b/metrics/test/test_return_statements.py
@@ -8,7 +8,9 @@ from metrics.return_statements import ReturnStatements
 class TestReturnStatements(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_return_statements"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_return_statements"), "python"
+        )
         self._returnstmnt = ReturnStatements()
         self._returnstmnt.set_coordinator(self._coordinator)
 

--- a/metrics/test/test_similar_codeblocks.py
+++ b/metrics/test/test_similar_codeblocks.py
@@ -1,25 +1,24 @@
 from pathlib import Path
-import subprocess
 import unittest
 import os
+from byoqm.source_coordinator.source_coordinator import SourceCoordinator
+from metrics.similar_codeblocks import SimilarBlocksofCode
 
 
 class TestSimilarCodeBlocks(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-
+        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_similar_codeblocks"),"python")
+        self._similarcode = SimilarBlocksofCode()
+        self._similarcode.set_coordinator(self._coordinator)
+        
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),
         "CPD doesn't exist in the environment",
     )
     def test_similar_codeblocks_given_file_returns_1(self):
-        cmd = [
-            "./metrics/similar_codeblocks.py",
-            "./metrics/test/data/test_data_similar_codeblocks",
-        ]
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-        result = process.stdout.decode("utf-8").strip()
-        self.assertEqual(result, "1")
+        result = self._similarcode.run()
+        self.assertEqual(result, 1)
 
     def tearDown(self):
         os.chdir(Path("metrics/test").resolve())

--- a/metrics/test/test_similar_codeblocks.py
+++ b/metrics/test/test_similar_codeblocks.py
@@ -12,7 +12,7 @@ class TestSimilarCodeBlocks(unittest.TestCase):
             Path("./metrics/test/data/test_data_similar_codeblocks"), "python"
         )
         self._similarcode = SimilarBlocksofCode()
-        self._similarcode.set_coordinator(self._coordinator)
+        self._similarcode.coordinator = self._coordinator
 
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),

--- a/metrics/test/test_similar_codeblocks.py
+++ b/metrics/test/test_similar_codeblocks.py
@@ -8,10 +8,12 @@ from metrics.similar_codeblocks import SimilarBlocksofCode
 class TestSimilarCodeBlocks(unittest.TestCase):
     def setUp(self):
         os.chdir("../../")
-        self._coordinator = SourceCoordinator(Path("./metrics/test/data/test_data_similar_codeblocks"),"python")
+        self._coordinator = SourceCoordinator(
+            Path("./metrics/test/data/test_data_similar_codeblocks"), "python"
+        )
         self._similarcode = SimilarBlocksofCode()
         self._similarcode.set_coordinator(self._coordinator)
-        
+
     @unittest.skipIf(
         not os.path.exists("../../metrics/cpd"),
         "CPD doesn't exist in the environment",

--- a/metrics/test/test_similar_codeblocks.py
+++ b/metrics/test/test_similar_codeblocks.py
@@ -7,6 +7,8 @@ from metrics.similar_codeblocks import SimilarBlocksofCode
 
 class TestSimilarCodeBlocks(unittest.TestCase):
     def setUp(self):
+        # chdir because paths are assumed to be relative from the project root but test
+        # paths start at the test file
         os.chdir("../../")
         self._coordinator = SourceCoordinator(
             Path("./metrics/test/data/test_data_similar_codeblocks"), "python"

--- a/models/tester_model.py
+++ b/models/tester_model.py
@@ -1,0 +1,30 @@
+from typing import Dict
+
+from tree_sitter import Language, Parser
+
+from byoqm.qualitymodel.qualitymodel import QualityModel
+
+
+class TesterModel(QualityModel):
+    def __init__(self):
+        self._py_language = Language("build/my-languages.so", "python")
+        self._parser = Parser()
+        self._parser.set_language(self._py_language)
+
+    def getDesc(self) -> Dict:
+        model = {
+            "metrics": {
+                "method_count": "./metrics/method_count.py",
+            },
+            "aggregations": {
+                "maintainability": self.maintainability,
+            },
+        }
+        return model
+
+    def maintainability(self, results: Dict) -> int | float:
+        return (
+            results["method_count"]
+        )
+
+model = TesterModel()

--- a/models/tester_model.py
+++ b/models/tester_model.py
@@ -23,8 +23,7 @@ class TesterModel(QualityModel):
         return model
 
     def maintainability(self, results: Dict) -> int | float:
-        return (
-            results["method_count"]
-        )
+        return results["method_count"]
+
 
 model = TesterModel()


### PR DESCRIPTION
## Describe your changes

I have made several changes in this PR.

I have changed `source_coordinator` so that it instead of keeping a single path to the source root, it will when instantiated keep a list of file paths to every file from the given root.

I have also changed so that every metric script now inherits from a Metric class, which is changed since the previous version was never used. This Metric class describes the required `run` method that metrics should have. If one would like to create a new Metric, they need to inherit from said Metric class, and provide a `run` method that returns an integer.

Lastly I have changed all tests so that they are coherent with the new architecture.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
