### PR TITLE
Remediation costs

### DIFF
--- a/metrics/code_size.py
+++ b/metrics/code_size.py
@@ -1,0 +1,43 @@
+from byoqm.metric.metric import Metric
+from byoqm.metric.result import Result
+from byoqm.metric.violation import Violation
+from byoqm.source_repository.source_repository import SourceRepository
+from byoqm.source_repository.query_translations import translate_to
+
+
+class CodeSize(Metric):
+    """
+    CodeSize measures the total lines of code, exlcuding comments, of the source code.
+    """
+
+    def __init__(self):
+        self._source_repository: SourceRepository = None
+
+    def run(self):
+        loc: int = 0
+        for file in self._source_repository.src_paths:
+            with open(file) as f:
+                loc = loc + self._parse(f, self._source_repository.getAst(file), file)
+        return loc
+
+    def _parse(self, file, ast, path):
+        """
+        Finds out whether or not a file is more than 250 lines long excluding comments
+        """
+        violations = []
+        query = self._source_repository.tree_sitter_language.query(
+            f"""
+            (_ [{translate_to[self._source_repository.language]["comment"]}] @comment)
+            """
+        )
+        captures = query.captures(ast.root_node)
+        count_comments = 0
+        for node, _ in captures:
+            count_comments += (
+                node.end_point[0] - node.start_point[0]
+            ) + 1  # length is zero indexed - therefore we add 1 at the end
+        loc = sum(1 for line in file if line.rstrip()) - count_comments
+        return loc
+
+
+metric = CodeSize()

--- a/models/code_climate.py
+++ b/models/code_climate.py
@@ -4,6 +4,28 @@ from byoqm.qualitymodel.qualitymodel import QualityModel
 
 
 class CodeClimate(QualityModel):
+    # Arbitrary choice of 30 minutes implementation time per line
+    _LINE_IMPLEMENTATiON_TIME = 30
+    # Code Climate reports 45 minutes to fix when 3 over the allowed cognitive complexity
+    _COGNITIVE_COMPLEXITY_REMEDIATION_COST = 45
+    # Too many return statements is reported as 30 minutes to fix
+    _RETURN_STATEMENTS_REMEDIATION_COST = 30
+    # Nested control flow is reported as taking 45 minutes to fix
+    _NESTED_CONTROL_FLOW_REMEDIATION_COST = 60
+    # When argument count is exactly one over the threshhold (5) it takes 35 minutes
+    # to fix It seems to scale with 10 minutes per argument hat is over when it is (6)
+    # then it takes 45 minutes to fix
+    _ARGUMENT_COUNT_REMEDIATION_COST = 35
+    # When the method is 9 lines over 25, Code Climate reports that it takes 1 hour to fix
+    _METHOD_LINES_REMEDIATION_COST = 60
+    # When the file is exactly 1 line over 250, Code Climate reports that it will take 2 hours to fix
+    _FILE_LINES_REMEDIATION_COST = 120
+    # When there is code duplication in 2 places, Code Climate reports that it will take 1 hour to fix
+    # It does, however, appear that they account for the size of the code snippet somehow as they sometimes
+    # report 45, 50 mminutes
+    _IDENTICAL_CODE_REMEDIATION_COST = 60
+    _SIMILAR_CODE_REMEDIATION_COST = 60
+
     def getDesc(self) -> Dict:
         model = {
             "metrics": {
@@ -13,13 +35,13 @@ class CodeClimate(QualityModel):
                 "complex_logic": "./metrics/complex_logic.py",
                 "method_count": "./metrics/method_count.py",
                 "return_statements": "./metrics/return_statements.py",
-                "identical_code": "./metrics/identical_codeblocks.py",
-                "similar_code": "./metrics/similar_codeblocks.py",
+                "identical-code": "./metrics/identical_codeblocks.py",
+                "similar-code": "./metrics/similar_codeblocks.py",
                 "nested_control_flow": "./metrics/nested_controlflows.py",
                 "cognitive_complexity": "./metrics/cognitive_complexity.py",
+                "code_size": "./metrics/code_size.py",
             },
             "aggregations": {
-                "cognitive_complexity": self.cognitive_complexity,
                 "Complexity": self.complexity,
                 "Duplication": self.duplication,
                 "Maintainability": self.maintainability,
@@ -30,14 +52,15 @@ class CodeClimate(QualityModel):
     def maintainability(self, results: Dict) -> str:
         # https://docs.codeclimate.com/docs/maintainability-calculation
         code_size: int = results["code_size"]
-        # Arbitrary choice of 30 minutes implementation time per line
-        implementation_time: int = code_size * 30
+        implementation_time: int = code_size * self._LINE_IMPLEMENTATiON_TIME
         technical_debt = results["Complexity"] + results["Duplication"]
         tech_debt_ratio: float = technical_debt / implementation_time
 
         return self._map_to_letter(tech_debt_ratio)
 
     def _map_to_letter(self, tech_debt_ratio: float) -> str:
+        # Intervals are taken from Pfeiffers and Lungu's Paper:
+        # Technical Debt and Maintainability: How do tools measure it?
         if 0 <= tech_debt_ratio <= 0.05:
             return "A"
         elif 0.05 < tech_debt_ratio <= 0.1:
@@ -51,33 +74,26 @@ class CodeClimate(QualityModel):
 
     def complexity(self, results: Dict) -> int | float:
         return (
-            # Cognitive Complexity is reported as taking 45 minutes to fix
-            results["cognitive_complexity"] * 45
-            # Too many return statements is reported as 30 minutes to fix
-            + results["return_statements"].get_frequency() * 30
-            # Nested control flow is reported as taking 45 minutes to fix
-            + results["nested_control_flow"].get_frequency() * 45
-            # When argument count is exactly one over (5) it takes 35 minutes to fix
-            # It seems to scale with 10 minutes per argument hat is over when it is (6) then
-            # it takes 45 minutes to fix
-            + results["argument_count"].get_frequency() * 35
-            # When the method is 9 lines over 25, Code Climate reports that it takes 1 hour to fix
-            + results["method_lines"].get_frequency() * 60
-            # When the file is exactly 1 line over 250, Code Climate reports that it will take 2 hours to fix
-            + results["file_lines"].get_frequency() * 120
+            results["cognitive_complexity"].get_frequency()
+            * self._COGNITIVE_COMPLEXITY_REMEDIATION_COST
+            + results["return_statements"].get_frequency()
+            * self._RETURN_STATEMENTS_REMEDIATION_COST
+            + results["nested_control_flow"].get_frequency()
+            * self._NESTED_CONTROL_FLOW_REMEDIATION_COST
+            + results["argument_count"].get_frequency()
+            * self._ARGUMENT_COUNT_REMEDIATION_COST
+            + results["method_lines"].get_frequency()
+            * self._METHOD_LINES_REMEDIATION_COST
+            + results["file_lines"].get_frequency() * self._FILE_LINES_REMEDIATION_COST
         )
 
     def duplication(self, results: Dict) -> int | float:
         return (
-            # When there is code duplication in 2 places, Code Climate reports that it will take 1 hour to fix
-            # It does, however, appear that they account for the size of the code snippet somehow as they sometimes
-            # report 45, 50 mminutes
-            results["identical-code"].get_frequency() * 60
-            + results["similar-code"].get_frequency() * 60
+            results["identical-code"].get_frequency()
+            * self._IDENTICAL_CODE_REMEDIATION_COST
+            + results["similar-code"].get_frequency()
+            * self._SIMILAR_CODE_REMEDIATION_COST
         )
-
-    def cognitive_complexity(self, results: Dict):
-        return results["cognitive_complexity"].get_frequency()
 
 
 model = CodeClimate()

--- a/models/code_climate.py
+++ b/models/code_climate.py
@@ -22,9 +22,32 @@ class CodeClimate(QualityModel):
                 "cognitive_complexity": self.cognitive_complexity,
                 "Complexity": self.complexity,
                 "Duplication": self.duplication,
+                "Maintainability": self.maintainability,
             },
         }
         return model
+
+    def maintainability(self, results: Dict) -> str:
+        # https://docs.codeclimate.com/docs/maintainability-calculation
+        code_size: int = results["code_size"]
+        # Arbitrary choice of 30 minutes implementation time per line
+        implementation_time: int = code_size * 30
+        technical_debt = results["Complexity"] + results["Duplication"]
+        tech_debt_ratio: float = technical_debt / implementation_time
+
+        return self._map_to_letter(tech_debt_ratio)
+
+    def _map_to_letter(self, tech_debt_ratio: float) -> str:
+        if 0 <= tech_debt_ratio <= 0.05:
+            return "A"
+        elif 0.05 < tech_debt_ratio <= 0.1:
+            return "B"
+        elif 0.1 < tech_debt_ratio <= 0.2:
+            return "C"
+        elif 0.2 < tech_debt_ratio <= 0.5:
+            return "D"
+        else:
+            return "F"
 
     def complexity(self, results: Dict) -> int | float:
         return (

--- a/models/code_climate.py
+++ b/models/code_climate.py
@@ -28,18 +28,29 @@ class CodeClimate(QualityModel):
 
     def complexity(self, results: Dict) -> int | float:
         return (
-            results["cognitive_complexity"]
-            + results["return_statements"].get_frequency()
-            + results["nested_control_flow"].get_frequency()
-            + results["argument_count"].get_frequency()
-            + results["method_lines"].get_frequency()
-            + results["file_lines"].get_frequency()
+            # Cognitive Complexity is reported as taking 45 minutes to fix
+            results["cognitive_complexity"] * 45
+            # Too many return statements is reported as 30 minutes to fix
+            + results["return_statements"].get_frequency() * 30
+            # Nested control flow is reported as taking 45 minutes to fix
+            + results["nested_control_flow"].get_frequency() * 45
+            # When argument count is exactly one over (5) it takes 35 minutes to fix
+            # It seems to scale with 10 minutes per argument hat is over when it is (6) then
+            # it takes 45 minutes to fix
+            + results["argument_count"].get_frequency() * 35
+            # When the method is 9 lines over 25, Code Climate reports that it takes 1 hour to fix
+            + results["method_lines"].get_frequency() * 60
+            # When the file is exactly 1 line over 250, Code Climate reports that it will take 2 hours to fix
+            + results["file_lines"].get_frequency() * 120
         )
 
     def duplication(self, results: Dict) -> int | float:
         return (
-            results["identical_code"].get_frequency()
-            + results["similar_code"].get_frequency()
+            # When there is code duplication in 2 places, Code Climate reports that it will take 1 hour to fix
+            # It does, however, appear that they account for the size of the code snippet somehow as they sometimes
+            # report 45, 50 mminutes
+            results["identical-code"].get_frequency() * 60
+            + results["similar-code"].get_frequency() * 60
         )
 
     def cognitive_complexity(self, results: Dict):


### PR DESCRIPTION
## Describe your changes

I have implemented remediation costs and a technical debt ratio so we can calculate an overall letter grade like code climate does. I feel like I am misusing the frequencies output for these changes, so please come with recommendation about how to reconcile this.

The remediation costs are semi-arbitrary and I picked them from just looking at a run of code climate on the testing-data repository. While ours are constant, I am sure Code Climate scales the remediation costs based on the size of the violation. 

I can spend more time on it, depending how closely we want to calibrate this with Code Climate itself.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
