### PR TITLE
Refer to modu and not byoqm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ click = "^8.1.3"
 chardet = "^5.1.0"
 
 [tool.poetry.scripts]
-modu="byoqm.main:load"
+modu="modu.main:load"
 test="metrics.test.test_all:run"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Describe your changes

#100 introduced a change where `poetry run modu` referred to the `byoqm` namespace incorrectly (since it is now `modu`).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
