### PR TITLE
Fix/utf 8 sig

### DIFF
--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -12,6 +12,7 @@ _CHARDET_ENCODINGS_TO_CPD = {
     "ASCII": "US-ASCII",
     "ISO-8859-1": "ISO-8859-1",
     "UTF-8": "UTF-8",
+    "UTF-8-SIG": "UTF-8",
     "UTF-16": "UTF-16",
     "UTF-16BE": "UTF-16BE",
     "UTF-16LE": "UTF-16LE",
@@ -33,6 +34,7 @@ class IdenticalBlocksofCode(Metric):
         """
         violations = []
         for file, file_info in self._source_repository.files.items():
+            logging.warn(f"Idenitcal code for {file_info}")
             filestring = f"{file}"
             cpd_encoding = _CHARDET_ENCODINGS_TO_CPD[file_info.encoding]
 

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -13,6 +13,7 @@ _CHARDET_ENCODINGS_TO_CPD = {
     "ASCII": "US-ASCII",
     "ISO-8859-1": "ISO-8859-1",
     "UTF-8": "UTF-8",
+    "UTF-8-SIG": "UTF-8",
     "UTF-16": "UTF-16",
     "UTF-16BE": "UTF-16BE",
     "UTF-16LE": "UTF-16LE",

--- a/modu/source_repository/source_repository.py
+++ b/modu/source_repository/source_repository.py
@@ -13,6 +13,8 @@ SUPPORTED_ENCODINGS: List[str] = [
     "ASCII",
     "ISO-8859-1",
     "UTF-8",
+    # UTF-8-SIG files have a BOM, using UTF-8-SIG will correctly read the BOM as meta-data
+    "UTF-8-SIG",
     "UTF-16BE",
     "UTF-16LE",
     "UTF-16",
@@ -99,7 +101,7 @@ class SourceRepository:
                     file_infos[f] = file_info
                 else:
                     logging.warn(
-                        f"Excluding f{file_info.file_path} from analysis. (Language: {file_info.language}, encoding: {file_info.encoding})"
+                        f"Excluding {file_info.file_path} from analysis. (Language: {file_info.language}, encoding: {file_info.encoding})"
                     )
 
         return file_infos
@@ -118,6 +120,9 @@ class SourceRepository:
                 programming_language = JAVA
             case _:
                 programming_language = UNKNOWN_LANGUAGE
+
+        if programming_language == UNKNOWN_LANGUAGE:
+            return FileInfo(file_path, UNKNOWN_ENCODING, UNKNOWN_LANGUAGE)
 
         encoding: str = UNKNOWN_ENCODING
         with file_path.open("rb") as file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ click = "^8.1.3"
 chardet = "^5.1.0"
 
 [tool.poetry.scripts]
-modu="byoqm.main:load"
+modu="modu.main:load"
 test="metrics.test.test_all:run"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Describe your changes

Merge after #102.

`chardet` was reporting `UTF-X-SIG` in practice, but we were ignoring these files. These are UTF-X encoded files with a BOM. You can read more about BOMs here: https://en.wikipedia.org/wiki/Byte_order_mark.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
