### PR TITLE
Remove logging statement from identical_code

### DIFF
--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -34,7 +34,6 @@ class IdenticalBlocksofCode(Metric):
         """
         violations = []
         for file, file_info in self._source_repository.files.items():
-            logging.warn(f"Idenitcal code for {file_info}")
             filestring = f"{file}"
             cpd_encoding = _CHARDET_ENCODINGS_TO_CPD[file_info.encoding]
 


### PR DESCRIPTION
## Describe your changes

A logging statement and its corresponding import statement was lost in a merge.

Logging was used for debugging purposes and doesn't need to be there.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
