### PR TITLE
Return Early from _inspect_file using Prog. Language

### DIFF
--- a/modu/source_repository/source_repository.py
+++ b/modu/source_repository/source_repository.py
@@ -26,6 +26,7 @@ UNKNOWN_ENCODING = "unknown"
 PYTHON = "python"
 C_SHARP = "c_sharp"
 JAVA = "java"
+SUPPORTED_LANGUAGES: List[str] = [PYTHON, C_SHARP, JAVA]
 UNKNOWN_LANGUAGE = "unknown"
 
 
@@ -121,6 +122,10 @@ class SourceRepository:
             raise ValueError(f"_inspect_file expects that ${file_path} is a file")
 
         programming_language: str = self._detect_language(file_path)
+        if programming_language not in SUPPORTED_LANGUAGES:
+            # Performance "optimization" to not check the encoding files if the language
+            # alone will exclude the file
+            return FileInfo(file_path, UNKNOWN_ENCODING, programming_language)
 
         encoding: str = UNKNOWN_ENCODING
         with file_path.open("rb") as file:


### PR DESCRIPTION
## Describe your changes

Make `_inspect_file` return early (i.e. before detecting the encoding of a file) if we already have determined that it is an unsupported language. This can be considered a "performance optimization" to avoid detecting the character encoding of as many files.

Running on flask before the change:
![image](https://user-images.githubusercontent.com/74768013/234567981-53dd8dff-af86-4d45-b113-8549b8290a0c.png)

Running on flask fter the change:
![image](https://user-images.githubusercontent.com/74768013/234568021-cf2d1ca4-e5db-40a8-8055-fec43a99913d.png)

A thing that has struck me as I am writing this: If we do this, we exclude many many files that might be interesting to metric writers. For example, no git file will ever be included, which there was a use case for when calculating the truck-factor. So are we perhaps being too restrictive with this change?

Personally, I think a better way to handle this, is to create more fleshed out ignore files for the experiment where we know our code_climate implementation really only ever needs to look at java/python/c-sharp files.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
