### PR TITLE
Remove non instance source repo

### DIFF
--- a/metrics/argument_count.py
+++ b/metrics/argument_count.py
@@ -7,7 +7,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class ArgumentCount(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/code_size.py
+++ b/metrics/code_size.py
@@ -16,7 +16,7 @@ class CodeSize(Metric):
     """
 
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         loc: int = 0

--- a/metrics/cognitive_complexity.py
+++ b/metrics/cognitive_complexity.py
@@ -12,7 +12,7 @@ from core.source_repository.source_repository import SourceRepository
 
 class CognitiveComplexity(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository | None = None
+        pass
 
     def run(self) -> Result:
         """

--- a/metrics/complex_logic.py
+++ b/metrics/complex_logic.py
@@ -7,7 +7,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class ComplexLogic(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/file_length.py
+++ b/metrics/file_length.py
@@ -12,7 +12,7 @@ from metrics.util.language_util import (
 
 class FileLength(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/identical_codeblocks.py
+++ b/metrics/identical_codeblocks.py
@@ -12,7 +12,7 @@ TOKENS = 35
 
 class IdenticalBlocksofCode(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self) -> Result:
         return self._identical_blocks_of_code()
@@ -32,7 +32,7 @@ class IdenticalBlocksofCode(Metric):
         to_inspect = str(to_inspect)
         to_inspect = to_inspect[1 : (len(to_inspect) - 1)]
         res = subprocess.run(
-            f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --dir {to_inspect} --format xml",
+            f"metrics/cpd/bin/pmd cpd --minimum-tokens {TOKENS} --skip-lexical-errors --dir {to_inspect} --format xml",
             shell=True,
             capture_output=True,
             text=True,

--- a/metrics/method_count.py
+++ b/metrics/method_count.py
@@ -7,7 +7,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class MethodCount(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/method_length.py
+++ b/metrics/method_length.py
@@ -9,7 +9,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class MethodLength(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/nested_controlflows.py
+++ b/metrics/nested_controlflows.py
@@ -7,7 +7,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class NestedControlflows(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/return_statements.py
+++ b/metrics/return_statements.py
@@ -7,7 +7,7 @@ from metrics.util.language_util import translate_to, SUPPORTED_LANGUAGES
 
 class ReturnStatements(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         violations = []

--- a/metrics/similar_codeblocks.py
+++ b/metrics/similar_codeblocks.py
@@ -13,7 +13,7 @@ TOKENS = 35
 
 class SimilarBlocksofCode(Metric):
     def __init__(self):
-        self._source_repository: SourceRepository = None
+        pass
 
     def run(self):
         return self._similar_blocks_of_code()
@@ -31,7 +31,7 @@ class SimilarBlocksofCode(Metric):
         to_inspect = str(to_inspect)
         to_inspect = to_inspect[1 : (len(to_inspect) - 1)]
         res = subprocess.run(
-            f"metrics/cpd/bin/run.sh cpd --minimum-tokens {TOKENS} --skip-lexical-errors --ignore-identifiers --ignore-literals --dir {to_inspect} --format xml",
+            f"metrics/cpd/bin/pmd cpd --minimum-tokens {TOKENS} --skip-lexical-errors --ignore-identifiers --ignore-literals --dir {to_inspect} --format xml",
             shell=True,
             capture_output=True,
             text=True,

--- a/metrics/test/test_similar_codeblocks.py
+++ b/metrics/test/test_similar_codeblocks.py
@@ -25,7 +25,7 @@ class TestSimilarCodeBlocks(unittest.TestCase):
         lines = [
             (loc.first_line, loc.last_line) for loc in result.get_violation_locations()
         ]
-        expected_lines = [(3, 11), (16, 24)]
+        expected_lines = [(1, 11), (14, 24)]
         self.assertCountEqual(lines, expected_lines)
 
 


### PR DESCRIPTION
## Describe your changes

Previously we set a variable source_repository in each metric to `None`, as the variable could be set upon initialization due to our dynamic importing. However, we have now removed the field entirely, as it is not necessary upon construction, but only after it has been set in the `run` module.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Have I requested and notified the boys for review of the pull-request?
